### PR TITLE
Allow empty buffer

### DIFF
--- a/portal/buffers.py
+++ b/portal/buffers.py
@@ -14,6 +14,7 @@ class SendBuffer:
     buffers = tuple(
          x.cast('c') if isinstance(x, memoryview) else x for x in buffers)
     length = sum(len(x) for x in buffers)
+    assert all(len(x) for x in buffers)
     assert 1 <= length, length
     assert not maxsize or length <= length, (length, maxsize)
     lenbuf = length.to_bytes(8, 'little', signed=False)

--- a/portal/buffers.py
+++ b/portal/buffers.py
@@ -14,7 +14,6 @@ class SendBuffer:
     buffers = tuple(
          x.cast('c') if isinstance(x, memoryview) else x for x in buffers)
     length = sum(len(x) for x in buffers)
-    assert all(len(x) for x in buffers)
     assert 1 <= length, length
     assert not maxsize or length <= length, (length, maxsize)
     lenbuf = length.to_bytes(8, 'little', signed=False)

--- a/portal/packlib.py
+++ b/portal/packlib.py
@@ -67,7 +67,7 @@ def unpack(buffer):
       leaves.append(buffer)
     elif spec[0] == 'array':
       shape, dtype = spec[1:]
-      if buffer == b'\x00':
+      if buffer == b'\x00' and shape == [0]  and dtype == '<f8':
         leaves.append(np.array([], dtype=dtype))
       else:
         leaves.append(np.frombuffer(buffer, dtype).reshape(shape))

--- a/portal/packlib.py
+++ b/portal/packlib.py
@@ -30,7 +30,10 @@ def pack(data):
           "Array is not contiguous in memory. Use " +
           "np.asarray(arr, order='C') before passing the data into pack().")
       specs.append(['array', value.shape, value.dtype.str])
-      buffers.append(value.data.cast('c'))
+      if value.size == 0: 
+        buffers.append(b'\x00')
+      else:
+        buffers.append(value.data.cast('c'))
     elif isinstance(value, sharray.SharedArray):
       specs.append(['sharray', *value.__getstate__()])
       buffers.append(b'\x00')
@@ -64,7 +67,10 @@ def unpack(buffer):
       leaves.append(buffer)
     elif spec[0] == 'array':
       shape, dtype = spec[1:]
-      leaves.append(np.frombuffer(buffer, dtype).reshape(shape))
+      if buffer == b'\x00':
+        leaves.append(np.array([], dtype=dtype))
+      else:
+        leaves.append(np.frombuffer(buffer, dtype).reshape(shape))
     elif spec[0] == 'sharray':
       assert buffer == b'\x00'
       leaves.append(sharray.SharedArray(*spec[1:]))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -370,3 +370,24 @@ class TestServer:
     assert client.fn(42).result() == 42
     client.close()
     server.close()
+
+  @pytest.mark.parametrize('Server', SERVERS)
+  def test_empty_array(self, Server):
+    port = portal.free_port()
+    server = Server(port)
+    
+    def get_empty_array():
+      return []
+    server.bind('get_empty_array', get_empty_array)
+    
+    def get_dict_with_empty_array():
+      return {'empty_array': np.array([])}
+    server.bind('get_dict_with_empty_array', get_dict_with_empty_array)
+    
+    server.start(block=False)
+    client = portal.Client(port)
+    assert np.array_equal(client.get_empty_array().result(), np.array([]))
+    assert np.array_equal(client.get_dict_with_empty_array().result()['empty_array'], np.array([]))
+
+    client.close()
+    server.close()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -377,17 +377,23 @@ class TestServer:
     server = Server(port)
     
     def get_empty_array():
-      return []
+      return np.array([])
     server.bind('get_empty_array', get_empty_array)
     
     def get_dict_with_empty_array():
       return {'empty_array': np.array([])}
     server.bind('get_dict_with_empty_array', get_dict_with_empty_array)
+
+    def get_false_array():
+      return np.array([False])
+    server.bind('get_false_array', get_false_array)
     
     server.start(block=False)
     client = portal.Client(port)
+
     assert np.array_equal(client.get_empty_array().result(), np.array([]))
     assert np.array_equal(client.get_dict_with_empty_array().result()['empty_array'], np.array([]))
+    assert np.array_equal(client.get_false_array().result(), np.array([False]))
 
     client.close()
     server.close()


### PR DESCRIPTION
Hi, we noticed that Portal currently doesn’t support empty arrays. Would it be possible to add support for this feature?